### PR TITLE
[사용자 정보] 유저 테이블을 구현

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/BackendApplication.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/BackendApplication.java
@@ -2,6 +2,7 @@ package woorifisa.goodfriends.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class BackendApplication {

--- a/backend/src/main/java/woorifisa/goodfriends/backend/BackendApplication.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/BackendApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing //2
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/Nickname.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/Nickname.java
@@ -1,0 +1,26 @@
+package woorifisa.goodfriends.backend.user.domain;
+
+import lombok.Getter;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.regex.Pattern;
+
+@Getter
+@Embeddable
+public class Nickname {
+
+    private static final Pattern PATTERN = Pattern.compile("^[0-9a-zA-Z가-힣]+(?:\\\\s+[0-9a-zA-Z가-힣]+)*$");
+    private static final int MIN_LENGTH = 1;
+    private static final int MAX_LENGTH = 20;
+
+    @Column(name = "nickname", unique = true)
+    private String value;
+
+    protected Nickname() {
+    }
+
+    public Nickname(String value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/Nickname.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/Nickname.java
@@ -1,6 +1,7 @@
 package woorifisa.goodfriends.backend.user.domain;
 
 import lombok.Getter;
+import woorifisa.goodfriends.backend.user.exception.InvalidNicknameException;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -21,6 +22,14 @@ public class Nickname {
     }
 
     public Nickname(String value) {
+        validateNickname(value);
         this.value = value;
+    }
+
+    private void validateNickname(String value) {
+        if(value.length() < MIN_LENGTH || value.length() > MAX_LENGTH
+                || !PATTERN.matcher(value).matches()) {
+            throw new InvalidNicknameException();
+        }
     }
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
@@ -1,9 +1,15 @@
 package woorifisa.goodfriends.backend.user.domain;
 
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class) // 3, 4
 public class User {
 
     @Id
@@ -17,6 +23,12 @@ public class User {
     private Nickname nickname;
 
     private int ban;
+
+    @CreatedDate // 1
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // 1
+    private LocalDateTime lastModifiedAt;
 
     protected User() {
     }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
@@ -1,0 +1,47 @@
+package woorifisa.goodfriends.backend.user.domain;
+
+
+import javax.persistence.*;
+
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    private Nickname nickname;
+
+    private int ban;
+
+    protected User() {
+    }
+
+    public User(final String email, final Nickname nickname, int ban) {
+
+        this.email = email;
+        this.nickname = nickname;
+        this.ban = ban;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Nickname getNickname() {
+        return nickname;
+    }
+
+    public int getBan() {
+        return ban;
+    }
+
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
@@ -4,13 +4,18 @@ package woorifisa.goodfriends.backend.user.domain;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import woorifisa.goodfriends.backend.user.exception.InvalidUserException;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class) // 3, 4
 public class User {
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-z0-9._-]+@[a-z]+[.]+[a-z]{2,3}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,10 +39,18 @@ public class User {
     }
 
     public User(final String email, final Nickname nickname, int ban) {
+        validateEmail(email);
 
         this.email = email;
         this.nickname = nickname;
         this.ban = ban;
+    }
+
+    private void validateEmail(final String email) {
+        Matcher matcher = EMAIL_PATTERN.matcher(email);
+        if(!matcher.matches()) {
+            throw new InvalidUserException();
+        }
     }
 
     public Long getId() {

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/exception/InvalidNicknameException.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/exception/InvalidNicknameException.java
@@ -1,0 +1,10 @@
+package woorifisa.goodfriends.backend.user.exception;
+
+public class InvalidNicknameException extends RuntimeException {
+
+    private static final String MESSAGE = "잘못된 닉네임 형식입니다.";
+
+    public InvalidNicknameException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/exception/InvalidUserException.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/exception/InvalidUserException.java
@@ -1,0 +1,12 @@
+package woorifisa.goodfriends.backend.user.exception;
+
+public class InvalidUserException extends RuntimeException {
+
+    public InvalidUserException(final String message) {
+        super();
+    }
+
+    public InvalidUserException() {
+        this("잘못된 회원 정보입니다.");
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요

Close #34 

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 유저에 대한 엔티티 테이블 생성했습니다.
- [x] JPA에서 테이블 생성시 자동으로 생성 시간, 수정 시간 생성하도록 구현했습니다.
- [x] 유저 테이블안에 이메일과 닉네임에 대한 예외 처리를 구현했습니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- JPA에서 테이블 생성시 자동으로 생성 시간, 수정 시간에 대한 내용은 다른 기능에도 활용할 것 같아서, 나중에 리팩터링을 통해 조금더 가독성있게 구현하겠습니다!
