### PR TITLE
Feature/87(로그인한 유저에 인증/인가를 구현)

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/AuthService.java
@@ -44,4 +44,10 @@ public class AuthService {
         eventPublisher.publishEvent(new UserSavedEvent(saveUser.getId()));
         return saveUser;
     }
+
+    public Long extractMemberId(String accessToken) {
+        Long userId = tokenCreator.extractPayLoad(accessToken);
+        userRepository.validateExistById(userId);
+        return userId;
+    }
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/AuthTokenCreator.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/AuthTokenCreator.java
@@ -20,4 +20,10 @@ public class AuthTokenCreator implements TokenCreator {
 
         return new AuthToken(id, accessToken);
     }
+
+    @Override
+    public Long extractPayLoad(String accessToken) {
+        tokenProvider.validateToken(accessToken);
+        return Long.valueOf(tokenProvider.getPayload(accessToken));
+    }
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/JwtTokenProvider.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/JwtTokenProvider.java
@@ -8,6 +8,8 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -21,17 +23,17 @@ import woorifisa.goodfriends.backend.auth.exception.InvalidTokenException;
 public class JwtTokenProvider implements TokenProvider {
 
     private final SecretKey key;
-    private final long accessTokenValidityInMilliseconds;
+    private final long accessTokenValidityInMinutes; // 변경: 분 단위로 유효 기간 설정
 
     public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") final String secretKey,
-                            @Value("${security.jwt.token.access.expire-length}") final long accessTokenValidityInMilliseconds) {
+                            @Value("${security.jwt.token.access.expire-length}") final long accessTokenValidityInMinutes) {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-        this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds;
+        this.accessTokenValidityInMinutes = accessTokenValidityInMinutes;
     }
 
     @Override
     public String createAccessToken(String payload) {
-        return createToken(payload, accessTokenValidityInMilliseconds);
+        return createToken(payload, TimeUnit.MINUTES.toMillis(accessTokenValidityInMinutes));
     }
 
     public String createToken(final String payload, final Long validityInMilliseconds) {

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/TokenCreator.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/TokenCreator.java
@@ -5,4 +5,6 @@ import woorifisa.goodfriends.backend.auth.domain.AuthToken;
 // 토큰을 생성하는 기능을 추상화한 클래스
 public interface TokenCreator {
     AuthToken createAuthToken(final Long memberId);
+
+    Long extractPayLoad(String accessToken);
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/TokenProvider.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/TokenProvider.java
@@ -3,4 +3,8 @@ package woorifisa.goodfriends.backend.auth.application;
 
 public interface TokenProvider {
     String createAccessToken(final String payload);
+
+    void validateToken(String accessToken);
+
+    String getPayload(String accessToken);
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/dto/LoginUser.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/dto/LoginUser.java
@@ -1,0 +1,17 @@
+package woorifisa.goodfriends.backend.auth.dto;
+
+public class LoginUser {
+
+    private Long id;
+
+    public LoginUser() {
+    }
+
+    public LoginUser(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/exception/EmptyAuthorizationHeaderException.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/exception/EmptyAuthorizationHeaderException.java
@@ -1,0 +1,11 @@
+package woorifisa.goodfriends.backend.auth.exception;
+
+public class EmptyAuthorizationHeaderException extends RuntimeException{
+
+    public EmptyAuthorizationHeaderException(final String message) {
+        super();
+    }
+    public EmptyAuthorizationHeaderException() {
+        this("Header에 Authorization이 존재하지 않습니다.");
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/exception/InvalidTokenException.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/exception/InvalidTokenException.java
@@ -1,0 +1,16 @@
+package woorifisa.goodfriends.backend.auth.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException(final String message) {
+        super(message);
+    }
+
+    public InvalidTokenException() {
+        this("유효하지 않은 토큰입니다.");
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthenticationPrincipal.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthenticationPrincipal.java
@@ -1,0 +1,11 @@
+package woorifisa.goodfriends.backend.auth.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,37 @@
+package woorifisa.goodfriends.backend.auth.presentation;
+
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import woorifisa.goodfriends.backend.auth.application.AuthService;
+import woorifisa.goodfriends.backend.auth.dto.LoginUser;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthService authService;
+
+    public AuthenticationPrincipalArgumentResolver(final AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = AuthorizationExtractor.extract(request);
+        Long id = authService.extractMemberId(accessToken);
+        return new LoginUser(id);
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthorizationExtractor.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthorizationExtractor.java
@@ -1,0 +1,29 @@
+package woorifisa.goodfriends.backend.auth.presentation;
+
+import org.springframework.http.HttpHeaders;
+import woorifisa.goodfriends.backend.auth.exception.EmptyAuthorizationHeaderException;
+import woorifisa.goodfriends.backend.auth.exception.InvalidTokenException;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
+
+public class AuthorizationExtractor {
+
+    private static final String BEARER_TYPE = "Bearer ";
+
+    public static String extract(final HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (Objects.isNull(authorizationHeader)) {
+            throw new EmptyAuthorizationHeaderException();
+        }
+
+        validateAuthorizationFormat(authorizationHeader);
+        return authorizationHeader.substring(BEARER_TYPE.length()).trim();
+    }
+
+    private static void validateAuthorizationFormat(final String authorizationHeader) {
+        if (!authorizationHeader.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+            throw new InvalidTokenException("token 형식이 잘못 되었습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package woorifisa.goodfriends.backend.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -14,8 +15,12 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final List<String> allowOriginUrlPatterns;
 
-    public WebConfig(@Value("${cors.allow-origin.urls}") final List<String> allowOriginUrlPatterns) {
+    private final HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver;
+
+    public WebConfig(@Value("${cors.allow-origin.urls}") final List<String> allowOriginUrlPatterns,
+                    final HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver) {
         this.allowOriginUrlPatterns = allowOriginUrlPatterns;
+        this.authenticationPrincipalArgumentResolver = authenticationPrincipalArgumentResolver;
     }
 
     @Override
@@ -27,5 +32,9 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("*")
                 .allowedOrigins(patterns)
                 .allowCredentials(true);
+    }
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authenticationPrincipalArgumentResolver);
     }
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/application/UserService.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/application/UserService.java
@@ -1,0 +1,23 @@
+package woorifisa.goodfriends.backend.user.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woorifisa.goodfriends.backend.user.domain.User;
+import woorifisa.goodfriends.backend.user.domain.UserRepository;
+import woorifisa.goodfriends.backend.user.dto.response.UserResponse;
+import woorifisa.goodfriends.backend.user.exception.NoSuchUserException;
+
+@Transactional
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+    public UserResponse findById(final Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(NoSuchUserException::new);
+        return new UserResponse(user);
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/UserRepository.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/UserRepository.java
@@ -18,4 +18,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
                 .orElseThrow(NoSuchUserException::new);
     }
     Optional<User> findByEmail(final String email);
+
+    default void validateExistById(final Long id) {
+        if(!existsById(id)) {
+            throw new NoSuchUserException();
+        }
+    }
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/dto/response/UserResponse.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/dto/response/UserResponse.java
@@ -1,0 +1,36 @@
+package woorifisa.goodfriends.backend.user.dto.response;
+
+import woorifisa.goodfriends.backend.user.domain.User;
+
+public class UserResponse {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+
+    public UserResponse(Long id, String email, String nickname, String profileImageUrl) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+    public UserResponse(final User user) {
+        this(user.getId(), user.getEmail(),user.getNickname(), user.getProfileImageUrl());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/presentation/UserController.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/presentation/UserController.java
@@ -1,0 +1,28 @@
+package woorifisa.goodfriends.backend.user.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woorifisa.goodfriends.backend.auth.dto.LoginUser;
+import woorifisa.goodfriends.backend.auth.presentation.AuthenticationPrincipal;
+import woorifisa.goodfriends.backend.user.application.UserService;
+import woorifisa.goodfriends.backend.user.dto.response.UserResponse;
+
+@RequestMapping("/api/users")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(final UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> findMe(@AuthenticationPrincipal final LoginUser loginUser) {
+        UserResponse response = userService.findById(loginUser.getId());
+        return ResponseEntity.ok(response);
+
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요

Close #87 

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 로그인한 유저에 대한 인증/인가 기능을 구현했습니다.
- [x] 유저 본인 정보 조회 기능을 구현했습니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.

현재 https 연결을 안해서, 인증/인가에 대한 동작이 안됩니다.

그래서 가비아에서 도메인을 구입한 다음에, AWS의 [Route 53](https://us-east-1.console.aws.amazon.com/route53/v2/home#Home) 에서의 네임 서버(4개)를 `My 가비아 - 내가 구매한 도메인 DNS 서버 관리 - 네임 서버`에 추가시켰습니다.

구매한 도메인이 DNS 서버에 연결하는 소요 시간은 2-3일이 걸립니다.


## 참고 자료

- [가비아](https://www.gabia.com/)
- [내 서버에 HTTPS 설정하기](https://pium-official.github.io/apply-https/)
- [certbot instructions](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal)