### PR TITLE
Feature/148([관리자 페이지] 사용자 관리 상세 페이지에 계정 삭제버튼을 추가한다.)

### DIFF
--- a/frontend/src/constants/strings/admin.ts
+++ b/frontend/src/constants/strings/admin.ts
@@ -8,7 +8,7 @@ export const ADMIN_SIDEBAR = {
 };
 
 export const ADMIN = {
-  EDIT_USER_TITLE: '정보 수정',
+  EDIT_USER_TITLE: '정보 관리',
   BAN: '신고당한 횟수',
   MARK: '인증 뱃지',
   AVERRAGE: '평점',
@@ -18,7 +18,8 @@ export const ADMIN = {
   PHONE: '연락처',
   ADDRESS: '주소',
   SUSPEND: '활동 정지',
-  EDIT: '수정 완료'
+  EDIT: '수정 완료',
+  DELETE: '계정 삭제'
 };
 
 export const ADMIN_PRODUCT = {

--- a/frontend/src/views/admin/EditUserInfoView.vue
+++ b/frontend/src/views/admin/EditUserInfoView.vue
@@ -51,6 +51,7 @@
         <div class="work-buttons-1">
           <button class="work-btn" @click="clickSuspend">{{ ADMIN.SUSPEND }}</button>
           <button class="work-btn" @click="clickEdit">{{ ADMIN.EDIT }}</button>
+          <button class="work-btn" @click="clickDelete">{{ ADMIN.DELETE }}</button>
         </div>
       </div>
     </div>
@@ -77,10 +78,10 @@ const sex = ref();
 const phone = ref();
 const address = ref();
 
-//TODO: 활동정지/수정완료 기능
+//TODO: 활동정지/수정완료/계정삭제 기능
 const clickSuspend = () => {};
-
 const clickEdit = () => {};
+const clickDelete = () => {};
 </script>
 <style scoped>
 .editUserInfo-Page {
@@ -174,12 +175,12 @@ const clickEdit = () => {};
   justify-content: flex-end;
 }
 .work-buttons-1 {
-  width: 200px;
+  width: 275px;
   height: 100px;
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 20px;
+  gap: 10px;
 }
 
 .work-btn {


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
Close #148 

## ✍🏻 작업 내용
- 사용자 정보 수정 페이지 이름을 사용자 정보 관리 로 수정합니다. -> 완료
- 계정 삭제 버튼을 추가로 삽입합니다. -> 완료


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 클래스 혹은 메서드 이름을 XXX로 작성했는데, 혹시 더 이해하기 쉬운 명칭이 있을까요?
