### PR TITLE
fix/185(최초 회원가입한 유저가 일부 프로필 정보가 없을 경우 새로 생성해서 값을 넣어주도록 수정)

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/profile/application/ProfileService.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/profile/application/ProfileService.java
@@ -28,10 +28,19 @@ public class ProfileService {
         userRepository.save(user);
 
         Profile profile = profileRepository.findByUserId(userId)
-                .orElseThrow(() -> new RuntimeException("프로필을 찾을 수 없습니다."));
+                .orElse(null);
 
-        profile.updateMobilePhone(request.getMobileNumber());
-        profile.updateAddress(request.getAddress());
-        profileRepository.save(profile);
+        if(profile == null) { // 프로필을 등록하지 않은 경우 새로 생성해서 값을 넣어준다.
+            profileRepository.save(profile.builder()
+                    .user(user)
+                    .mobilePhone(request.getMobileNumber())
+                    .address(request.getAddress())
+                    .build());
+        }
+        else { // 기존에 프로필이 있는 경우, 프로필 정보(핸드폰, 주소)를 수정해서 저장한다.
+            profile.updateMobilePhone(request.getMobileNumber());
+            profile.updateAddress(request.getAddress());
+            profileRepository.save(profile);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요

- Close #185 

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

프로필을 등록하지 않는 않는 경우/등록한 경우에 따라 로직을 처리했습니다.

```java
public void update(Long userId, ProfileUpdateRequest request) {
        User user = userRepository.getById(userId);

        user.updateNickname(request.getNickName());
        userRepository.save(user);

        Profile profile = profileRepository.findByUserId(userId)
                .orElse(null);

        if(profile == null) { // 프로필을 등록하지 않은 경우 새로 생성해서 값을 넣어준다.
            profileRepository.save(profile.builder()
                    .user(user)
                    .mobilePhone(request.getMobileNumber())
                    .address(request.getAddress())
                    .build());
        }
        else { // 기존에 프로필이 있는 경우, 프로필 정보(핸드폰, 주소)를 수정해서 저장한다.
            profile.updateMobilePhone(request.getMobileNumber());
            profile.updateAddress(request.getAddress());
            profileRepository.save(profile);
        }
    }
```

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
