### PR TITLE
Fix/196(AdminController의 TokenResponse 임포트 제거)

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/admin/application/AdminService.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/admin/application/AdminService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import woorifisa.goodfriends.backend.admin.domain.Admin;
 import woorifisa.goodfriends.backend.admin.domain.AdminRepository;
-import woorifisa.goodfriends.backend.admin.dto.response.TokenResponse;
 import woorifisa.goodfriends.backend.admin.dto.response.UserLogRecordsResponse;
 import woorifisa.goodfriends.backend.admin.exception.InvalidAdminException;
 import woorifisa.goodfriends.backend.admin.exception.NotFoundAdminException;
@@ -48,7 +47,7 @@ public class AdminService {
 
 
     private final TokenCreator tokenCreator;
-    public AdminService(AdminRepository adminRepository, ProductRepository productRepository,
+    public AdminService(AdminRepository adminRepository,UserRepository userRepository, ProductRepository productRepository,
                         ProductImageRepository productImageRepository, S3Service s3Service,
                         TokenCreator tokenCreator) {
 

--- a/backend/src/main/java/woorifisa/goodfriends/backend/admin/presentation/AdminController.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/admin/presentation/AdminController.java
@@ -7,8 +7,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import woorifisa.goodfriends.backend.admin.application.AdminService;
 import woorifisa.goodfriends.backend.admin.dto.request.AdminLoginRequest;
-
-import woorifisa.goodfriends.backend.admin.dto.response.TokenResponse;
 import woorifisa.goodfriends.backend.admin.dto.response.UserLogRecordsResponse;
 import woorifisa.goodfriends.backend.auth.dto.response.AccessTokenResponse;
 import woorifisa.goodfriends.backend.product.dto.request.ProductSaveRequest;


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
Close #196 

## ✍🏻 작업 내용

- AdminController 의 import woorifisa.goodfriends.backend.admin.dto.response.TokenResponse; 를 제거

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 클래스 혹은 메서드 이름을 XXX로 작성했는데, 혹시 더 이해하기 쉬운 명칭이 있을까요?
