### PR TITLE
Refactor/192(Set-Cookie로 설정한 리프레시 토큰과 관련된 로직을 수정)

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/AuthTokenResponseHandler.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/application/AuthTokenResponseHandler.java
@@ -22,7 +22,7 @@ public class AuthTokenResponseHandler {
         // HttpOnly 설정시 클라이언트에서 쿠키에 직접 js 코드로 접근이 불가능하고
         // 이는 refreshToken 유효성 검사시 서버의 네트워크 통신을 한번 더 요구하고 추가 API 작성 및 클라이언트 OAuth 로직에서 복잡성을 유발하여
         // 현 기준 HttpOnly 옵션은 일단 사용을 안하는 것으로 결정
-        refreshTokenCookie.setHttpOnly(false);
+        refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setSecure(true); // https 옵션 설정
         refreshTokenCookie.setMaxAge(14 * 24 * 60 * 60); // 리프레시 토큰 유효 기간 설정 (14일)
         refreshTokenCookie.setPath("/"); // 쿠키의 유효 경로 설정 (애플리케이션 전체)

--- a/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthController.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/auth/presentation/AuthController.java
@@ -1,7 +1,14 @@
 package woorifisa.goodfriends.backend.auth.presentation;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import woorifisa.goodfriends.backend.auth.application.AuthService;
 import woorifisa.goodfriends.backend.auth.application.OAuthClient;
 import woorifisa.goodfriends.backend.auth.application.OAuthUri;
@@ -50,7 +57,7 @@ public class AuthController {
     // 리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급 받기
     @PostMapping("/token/access")
     public ResponseEntity<AccessTokenResponse> generateAccessToken(
-            @RequestHeader("refreshToken") String refreshToken) {
+            @CookieValue("refreshToken") String refreshToken) {
         TokenRenewalRequest tokenRenewalRequest = new TokenRenewalRequest(refreshToken);
         AccessTokenResponse response = authService.generateAccessToken(tokenRenewalRequest);
         return ResponseEntity.ok(response);


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요
>
> ex) #이슈번호, #이슈번호

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] HttpOnly `true`로 설정
- [x] `@PostMapping("/token/access")`에서 RequestHeader가 아닌 CookieValue 어노테이션으로 수정
  - 리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급할 때 프론트엔드는 Request Headers에 refreshToken 값이 들어있는 Cookie를 백엔드에게 요청하고, 백엔드는 요청받은 CookieValue 어노테이션을 통해 리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급하는 로직을 수행하게 됩니다.

### @PostMapping("/{oauthProvider}/token")

인가코드(code)와 redirectUri를 가지고 액세스 토큰과 리프레시 토큰을 발급한다.

> 액세스 토큰과 리프레시 토큰을 발급할 때 액세스 토큰은 body에 리프레시 토큰은 cookie에 저장됩니다.

![](https://github.com/woorifisa-projects/GoodFriends/assets/83820185/8a7409c7-bdc7-4357-ae74-f1140fb0adb0)

### @PostMapping("/token/access")

리프레시 토큰을 이용해서 새로운 액세스 토큰 발급

![](https://github.com/woorifisa-projects/GoodFriends/assets/83820185/b2d70a17-53b4-44fa-ba30-a480e263238e)

## 💬 리뷰 요구사항(선택)

